### PR TITLE
switch from `pip-tools` to `uv` in requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   `.dockerignore` now uses a whitelist of files to include, rather than a blacklist. H/T to [@mhlut](https://github.com/mhlut) for the [inspiration](https://marijkeluttekes.dev/blog/articles/2024/03/18/smaller-docker-images-by-using-a-blanket-ignore/).
 -   Now using maximum Python version (3.12) throughout CI for repo.
 -   In `settings.py`, `SENTRY_DSN` now correctly using `environs.env.url` to validate the URL from the environment and passing the URL string to `sentry_sdk.init`.
+-   `uv` explicitly added to template's `requirements.in` file.
+
+### Removed
+
+-   `pip-tools` has been removed from `requirements.in`, in favor of `uv`.
 
 ### Fixed
 

--- a/src/django_twc_project/requirements.in.jinja
+++ b/src/django_twc_project/requirements.in.jinja
@@ -33,7 +33,6 @@ httpx
 ipython
 model_bakery
 mypy
-pip-tools
 playwright
 pre-commit
 psycopg
@@ -48,6 +47,7 @@ pytest-xdist
 ruff
 sentry-sdk[django]
 types-croniter
+uv
 {%- if include_weasyprint %}
 weasyprint
 {%- endif %}


### PR DESCRIPTION
closes #72