### PR TITLE
move static tailwind utilities from plugin to CSS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+-   Added two CSS utilities previously set in the shared central Tailwind CSS config: `x-cloak` for hiding certain Alpine.js elements until Alpine has been initialized and the `htmx-indicator` for controlling the Z-index of the loading indicator.
+
 ## [2024.17]
 
 ### Added

--- a/src/django_twc_project/static/src/tailwind.css
+++ b/src/django_twc_project/static/src/tailwind.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  [x-cloak] {
+    display: none !important;
+  }
+
+  .htmx-indicator {
+    z-index: -9999;
+  }
+  .htmx-request .htmx-indicator {
+    z-index: 10;
+  }
+  .htmx-request.htmx-indicator {
+    z-index: 10;
+  }
+}


### PR DESCRIPTION
was causing an issue downstream if the project hadn't updated the central `@django-twc-ui/tailwind` custom Node package. since these are not dynamic and don't rely on any of the existing Tailwind config, better to just define them outright in the CSS file itself.