### PR TITLE
fix bug with database `ssl_require` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   Added `CSRF_COOKIE_SECURE = not DEBUG` setting to template.
 -   Added `AWS_S3_CUSTOM_DOMAIN` setting to template.
 
+### Fixed
+
+-   Fixed a bug with the `ssl_require` argument in the database config in `settings.py`. When building or testing, we sometimes fall back to just using SQLite to avoid having to spin up a Postgres database. However, SQLite doesn't know what to do with the `sql_require` argument, so we disable it for SQLite.
+
 ## [2024.19]
 
 ### Added

--- a/src/django_twc_project/{{ module_name }}/settings.py.jinja
+++ b/src/django_twc_project/{{ module_name }}/settings.py.jinja
@@ -60,14 +60,18 @@ DATABASES = {
         default="sqlite:///db.sqlite3",
         conn_max_age=600,  # 10 minutes
         conn_health_checks=True,
-        ssl_require=not DEBUG and not env.bool("CI", default=False),
+        ssl_require=not DEBUG
+        and not env.bool("CI", default=False)
+        and not env.str("DATABASE_URL", default="").startswith("sqlite://"),
     ),
     EMAIL_RELAY_DATABASE_ALIAS: env.dj_db_url(
         "EMAIL_RELAY_DATABASE_URL",
         default="sqlite:///email_relay.sqlite3",
         conn_max_age=600,  # 10 minutes
         conn_health_checks=True,
-        ssl_require=not DEBUG and not env.bool("CI", default=False),
+        ssl_require=not DEBUG
+        and not env.bool("CI", default=False)
+        and not env.str("EMAIL_RELAY_DATABASE_URL", default="").startswith("sqlite://"),
     ),
 }
 if not DEBUG and (


### PR DESCRIPTION
can come up when building or testing, we don't want to bother with ssl if sqlite is the specified database