### PR TITLE
remove deprecated version property in docker compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 -   `boto3` as an explicit dependency has been removed in favor of `django-storages[s3]`.
+-   Removed deprecated `version` property from all Docker `compose*.yml` files.
 
 ## [2024.23]
 

--- a/src/django_twc_project/compose.prod.yml.jinja
+++ b/src/django_twc_project/compose.prod.yml.jinja
@@ -1,5 +1,3 @@
-version: "3"
-
 x-app: &prod-app
   build:
     target: final

--- a/src/django_twc_project/compose.yml.jinja
+++ b/src/django_twc_project/compose.yml.jinja
@@ -1,5 +1,3 @@
-version: "3"
-
 x-app: &default-app
   build:
     context: .


### PR DESCRIPTION
https://nickjanetakis.com/blog/docker-tip-51-which-docker-compose-api-version-should-you-use
https://github.com/compose-spec/compose-spec/blob/77bd39a846442132495990c221d5aa3509ce19bc/04-version-and-name.md