### PR TITLE
refactor Justfile commands a bit based on recent tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -   Added our Data Analytics GitHub Team to the `CODEOWNERS` file for automatic review assignment to any PRs involving migrations.
 
+### Changed
+
+-   Adjusted various `Justfile` commands based on testing and feedback.
+
 ## [2024.24]
 
 ### Changed

--- a/src/django_twc_project/.env.example.jinja
+++ b/src/django_twc_project/.env.example.jinja
@@ -2,3 +2,4 @@ DATABASE_URL={{ postgres_uri_scheme }}://postgres:postgres@db:5432/postgres
 DEBUG=True
 DJANGO_SETTINGS_MODULE={{ module_name }}.settings
 EMAIL_RELAY_DATABASE_URL={{ postgres_uri_scheme }}://postgres:postgres@db:5432/email_relay
+JUST_UNSTABLE=True

--- a/src/django_twc_project/.just/django.just
+++ b/src/django_twc_project/.just/django.just
@@ -12,7 +12,6 @@ fmt:
 manage *COMMAND:
     @just docker command python -m manage {{ COMMAND }}
 
-# Alias for makemigrations
 alias mm := makemigrations
 
 # Generate Django migrations

--- a/src/django_twc_project/.just/docker.just
+++ b/src/django_twc_project/.just/docker.just
@@ -19,7 +19,10 @@ build-prod:
     docker compose -f compose.yml -f compose.prod.yml build
 
 # Stop and remove all containers, networks, images, and volumes
+[no-cd]
 clean:
+    #!/usr/bin/env bash
+    [[ ! -f .env ]] && just project envfile
     @just docker down --volumes --rmi local
 
 # Run a command within the 'app' container

--- a/src/django_twc_project/.just/documentation.just
+++ b/src/django_twc_project/.just/documentation.just
@@ -37,7 +37,7 @@ serve: cog
 upgrade:
     @just lock --upgrade
 
-[private]
 [no-cd]
+[private]
 cog:
     cog -r docs/just.md

--- a/src/django_twc_project/.just/project.just
+++ b/src/django_twc_project/.just/project.just
@@ -33,7 +33,7 @@ envfile:
     envfile = Path("{{ justfile_directory() }}/.env")
     envfile_example = Path("{{ justfile_directory() }}/.env.example")
 
-    if not envfile.exists():
+    if not envfile.exists() or envfile.stat().st_size == 0:
         envfile.write_text(envfile_example.read_text())
 
 # Sync .env file back to .env.example
@@ -85,6 +85,7 @@ lint: install-precommit
     @just project just-fmt
 
 # Setup project scaffolding
+[no-cd]
 setup:
     @just project envfile
     @just py venv

--- a/src/django_twc_project/.just/python.just.jinja
+++ b/src/django_twc_project/.just/python.just.jinja
@@ -38,7 +38,7 @@ lock *ARGS:
 # Run tests using pytest within the 'app' container, with optional arguments
 test *ARGS:
 {%- if include_vite %}
-    @just docker run app "-e DJANGO_VITE_DEV_SERVER_HOST=node" pytest {% raw %}{{ ARGS }}{% endraw %}
+    @just docker run app "-e DJANGO_VITE_DEV_SERVER_HOST=node" coverage run -m pytest {% raw %}{{ ARGS }}{% endraw %}
 {%- else %}
     @just docker command coverage run -m pytest {% raw %}{{ ARGS }}{% endraw %}
 {%- endif %}


### PR DESCRIPTION
- various linting
- create envfile if not there before calling docker compose down in `just docker clean`
- add coverage to pytest when vite template is chosen