### PR TITLE
migrate prettier to local pre-commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `prettier` pre-commit hook is now local instead of using the official mirror. The mirror has been deprecated and archived.
+
 ## [2024.32]
 
 ### Changed

--- a/src/django_twc_project/.pre-commit-config.yaml.jinja
+++ b/src/django_twc_project/.pre-commit-config.yaml.jinja
@@ -31,19 +31,6 @@ repos:
         additional_dependencies:
           - black==22.12.0
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        # lint the following with prettier:
-        # - javascript
-        # - typescript
-        # - JSX/TSX
-        # - CSS
-        # - yaml
-        # ignore any minified code
-        files: '^(?!.*\.min\..*)(?P<name>[\w-]+(\.[\w-]+)*\.(js|jsx|ts|tsx|yml|yaml|css))$'
-
   - repo: https://github.com/djlint/djLint
     rev: v1.34.1
     hooks:
@@ -52,6 +39,20 @@ repos:
 
   - repo: local
     hooks:
+      - id: prettier
+        name: Prettier
+        language: node
+        additional_dependencies:
+          - prettier@v4.0.0-alpha.9
+        entry: prettier
+        # lint the following with prettier:
+        # - javascript
+        # - typescript
+        # - JSX/TSX
+        # - CSS
+        # - yaml
+        # ignore any minified code
+        files: '^(?!.*\.min\..*)(?P<name>[\w-]+(\.[\w-]+)*\.(js|jsx|ts|tsx|yml|yaml|css))$'
       - id: rustywind
         name: rustywind Tailwind CSS class linter
         language: node


### PR DESCRIPTION
the "official" prettier mirror has been deprecated and archived