### PR TITLE
remove default GitHub token credentials from persisting after checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `persist-credentials: false` back to the `actions/checkout` step in the `test` step in the `test.yml` GitHub Action workflow. Persisting the default GitHub Token credentials causes an error when trying to install Node dependencies, as our `django-twc-ui/tailwind` dependency is in a private repository.
+
 ## [2024.39]
 
 ### Fixed

--- a/src/django_twc_project/.github/workflows/test.yml.jinja
+++ b/src/django_twc_project/.github/workflows/test.yml.jinja
@@ -39,6 +39,8 @@ jobs:
       EMAIL_RELAY_DATABASE_URL: {{ postgres_uri_scheme }}://postgres:postgres@localhost:5432/email-relay
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
causes an issue in the npm installation