### PR TITLE
temporarily remove prettier from pre-commit config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Removed
+
+- Prettier pre-commit stage in `.pre-commit-config.yaml` has been temporarily commented out and disabled. The pre-commit mirror this originally was pointing at was deprecated, and the Prettier project does not have an official one. I tried my hand at creating a local hook, but I have run in to issues with it actually running. Disabling for now till I have the time to dig in to what to do here.
+
 ### Fixed
 
 - Added `persist-credentials: false` back to the `actions/checkout` step in the `test` step in the `test.yml` GitHub Action workflow. Persisting the default GitHub Token credentials causes an error when trying to install Node dependencies, as our `django-twc-ui/tailwind` dependency is in a private repository.

--- a/src/django_twc_project/.pre-commit-config.yaml.jinja
+++ b/src/django_twc_project/.pre-commit-config.yaml.jinja
@@ -39,20 +39,20 @@ repos:
 
   - repo: local
     hooks:
-      - id: prettier
-        name: Prettier
-        language: node
-        additional_dependencies:
-          - prettier@v4.0.0-alpha.9
-        entry: prettier
-        # lint the following with prettier:
-        # - javascript
-        # - typescript
-        # - JSX/TSX
-        # - CSS
-        # - yaml
-        # ignore any minified code
-        files: '^(?!.*\.min\..*)(?P<name>[\w-]+(\.[\w-]+)*\.(js|jsx|ts|tsx|yml|yaml|css))$'
+      # - id: prettier
+      #   name: Prettier
+      #   language: node
+      #   additional_dependencies:
+      #     - prettier@v4.0.0-alpha.9
+      #   entry: prettier
+      #   # lint the following with prettier:
+      #   # - javascript
+      #   # - typescript
+      #   # - JSX/TSX
+      #   # - CSS
+      #   # - yaml
+      #   # ignore any minified code
+      #   files: '^(?!.*\.min\..*)(?P<name>[\w-]+(\.[\w-]+)*\.(js|jsx|ts|tsx|yml|yaml|css))$'
       - id: rustywind
         name: rustywind Tailwind CSS class linter
         language: node


### PR DESCRIPTION
the "official" pre-commit mirror has been deprecated with no official one coming from the actual prettier project. this local one for some reason does not work.

i want to come up with a solution for this, but i'm punting that for now and just commenting it out.