### PR TITLE
add common subcommands to the top-level `Justfile`

### DIFF
--- a/src/django_twc_project/Justfile.jinja
+++ b/src/django_twc_project/Justfile.jinja
@@ -32,11 +32,42 @@ clean:
     @just project clean
     @just docker clean
 
-# Open a bash shell within a specified container (default: 'app')
-shell CONTAINER="app":
+# Open a bash console within a specified container (default: 'app')
+console CONTAINER="app":
     @just docker run {% raw %}{{ CONTAINER }}{% endraw %} "" "/bin/bash"
 
-# Start development server
+# Stop local development environment
+down:
+    @just docker down
+
+# Run the linters on all files in project
+lint:
+    @just project lint
+
+# Generate lockfiles for all dependencies
+lock:
+    @just py lock
+    @just node lock
+
+# Print out the logs of all Docker containers, optionally specifying a container to focus on
+logs *ARGS:
+    @just docker logs {{ ARGS }}
+
+# Run Django migrations
+migrate *ARGS:
+    @just dj migrate {{ ARGS }}
+
+alias mm := makemigrations
+
+# Generate Django migrations
+makemigrations *ARGS:
+    @just dj makemigrations {{ ARGS }}
+
+# Run a Django management command
+manage *COMMAND:
+    @just dj manage {{ COMMAND }}
+
+# Start development server in foreground
 server:
     @just docker down
     @just bootstrap
@@ -55,8 +86,8 @@ setup:
     @just project lint
     @just docker down
 
-# Open a tool's interative console within a specified container (default: 'app')
-console CONTAINER="app" COMMAND="":
+# Open a tool's interative shell within a specified container (default: 'app')
+shell CONTAINER="app" COMMAND="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [ {% raw %}{{ CONTAINER }}{% endraw %} = 'db' ]; then
@@ -65,15 +96,25 @@ console CONTAINER="app" COMMAND="":
         COMMAND="node"
     elif [ "{% raw %}{{ CONTAINER }}{% endraw %}" = "app" ] || [ "{% raw %}{{ CONTAINER }}{% endraw %}" = "worker" ]; then
         COMMAND="ipython"
+    elif [ {% raw %}{{ CONTAINER }}{% endraw %} = 'dj' ]; then
+        COMMAND="python -m manage shell_plus"
     fi
     [ -n "{% raw %}{{ COMMAND }}{% endraw %}" ] && COMMAND="{% raw %}{{ COMMAND }}{% endraw %}"
     COMMAND="${COMMAND:-/bin/bash}"
     just docker run {% raw %}{{ CONTAINER }}{% endraw %} "" $COMMAND
 
-# Run all tests
+# Follow the logs of all Docker containers, optionally specifying a container to focus on
+tail *ARGS:
+    @just docker tail {{ ARGS }}
+
+# Run entire test suite, including generating code coverage
 test:
     @just py test
     @just py coverage-html
+
+# Start local development environment in background
+up:
+    @just docker start
 
 # Update local development environment
 update:
@@ -81,3 +122,8 @@ update:
     @just py lock
     @just node lock
     @just bootstrap
+
+# Upgrade all dependencies to their newest versions
+upgrade:
+    @just py upgrade
+    @just node upgrade

--- a/src/django_twc_project/Justfile.jinja
+++ b/src/django_twc_project/Justfile.jinja
@@ -67,11 +67,11 @@ makemigrations *ARGS:
 manage *COMMAND:
     @just dj manage {{ COMMAND }}
 
-# Start development server in foreground
-server:
-    @just docker down
+# Refresh local development environment
+refresh:
+    @just docker stop
     @just bootstrap
-    @just docker up
+    @just docker start
 
 # Setup local development environment
 setup:
@@ -103,6 +103,14 @@ shell CONTAINER="app" COMMAND="":
     COMMAND="${COMMAND:-/bin/bash}"
     just docker run {% raw %}{{ CONTAINER }}{% endraw %} "" $COMMAND
 
+# Start local development environment in background
+start:
+    @just docker start
+
+# Stop local development environment
+stop:
+    @just docker stop
+
 # Follow the logs of all Docker containers, optionally specifying a container to focus on
 tail *ARGS:
     @just docker tail {{ ARGS }}
@@ -112,9 +120,9 @@ test:
     @just py test
     @just py coverage-html
 
-# Start local development environment in background
+# Start local development environment in foreground
 up:
-    @just docker start
+    @just docker up
 
 # Update local development environment
 update:


### PR DESCRIPTION
closes #205 
closes #251 

| Command | Description |
| --- | --- |
| `bootstrap` | Prepare local environment by installing dependencies and building Docker containers |
| `clean` | Delete cache, coverage, and dependency directories and stop and delete Docker containers including volumes |
| `console`* | Open a bash shell in a Docker container |
| `down` | Stop docker compose stack |
| `lint` | Lint project |
| `lock` | Generate lockfiles for all project tools |
| `logs` | Print Docker Compose logs |
| `migrate` | Run Django migrations |
| `makemigrations`/`mm` | Generate Django migrations |
| `manage` | Run Django management command |
| `refresh`** | Bring down Docker Compose stack, bootstrap local environment, and start Docker Compose stack in the background |
| `setup` | Clean and bootstrap local environment, start Docker Compose stack, run Django migrations and create superuser account, and run tests, type checkers, and linters |
| `shell`* | Open a Docker container's runtime console (e.g. a Python REPL, psql, etc.) |
| `start` | Start the Docker Compose stack in the background |
| `stop` | Stop the Docker Compose stack|
| `tail` | Follow the Docker Compose logs|
| `test` | Run all project tests, including generating code coverage |
| `up` | Start the Docker Compose stack in the foreground |
| `update` | Pull latest Docker images, lock Python and Node dependencies, and bootstrap local environment |
| `upgrade` | Bump dependencies to latest versions |

### Breaking Changes
*`console` and `shell` commands have been swapped
**`server` command has been renamed to `refresh` and changed to starting the compose stack detached at the end, instead of in the foreground