### PR TITLE
fix installation commands in Justfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- All `uv pip install` commands now use the correct CLI syntax for installing from requirements files. When I migrated back from `uv pip sync` I failed to take in to account the slight differences between how dependencies are installed.
+
 ## [2024.44]
 
 ### Changed

--- a/src/django_twc_project/.just/documentation.just
+++ b/src/django_twc_project/.just/documentation.just
@@ -16,7 +16,7 @@ build LOCATION="docs/_build/html": cog
 # Install documentation dependencies
 [no-cd]
 install *ARGS:
-    $python -m uv pip install {{ ARGS }} docs/requirements.txt
+    $python -m uv pip install {{ ARGS }} -r docs/requirements.txt
 
 # Generate documentation requirements
 [no-cd]

--- a/src/django_twc_project/.just/python.just.jinja
+++ b/src/django_twc_project/.just/python.just.jinja
@@ -31,7 +31,7 @@ coverage-report: test
 # Install dependencies
 [no-cd]
 install *ARGS:
-    $python -m uv pip install {% raw %}{{ ARGS }}{% endraw %} requirements.txt requirements.dev.txt
+    $python -m uv pip install {% raw %}{{ ARGS }}{% endraw %} -r requirements.txt -r requirements.dev.txt
 
 # Generate requirements.txt file
 [no-cd]


### PR DESCRIPTION
When I migrated back from `uv pip sync` to `uv pip install`, I forgot to take in to account the differences in how the CLI commands are called.