### PR TITLE
more backporting of real world project Justfile changes to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Bumped all versions of the hooks in `.pre-commit-config.yaml`.
+- Altered all uses of the `--cov` `pytest` CLI flag from `pytest-cov`. This was unneeded as just by using the bare flag, the plugin uses the coverage configuration in `pyproject.toml`.
+- Coverage just commands in `.just/python.just` module have been shortened from `coverage` to `cov`.
+- Make sure that when specifying `dj` when calling `just shell` as the container to enter, actually enter the `app` container and call the `shell_plus` command.
+
+### Removed
+
+- Removed the `just refresh` command due to the vast overlap between it and the `just update` command.
+- The `test` command in `.just/python.just` has been removed as a prereq to the coverage commands. Depending on the order these are called, you could end up running the test suite more than once, defeating the purpose of the prereq. So we will just rely on calling the test command before the coverage commands.
 
 ## [2024.49]
 

--- a/src/django_twc_project/.github/workflows/test.yml.jinja
+++ b/src/django_twc_project/.github/workflows/test.yml.jinja
@@ -125,7 +125,7 @@ jobs:
       # https://hynek.me/articles/ditch-codecov-python/
       - name: Run tests
         run: |
-          time python -m pytest --durations 10 --reverse -p no:randomly -n auto --dist loadfile --cov={{ module_name }} --cov-report= --cov-config=pyproject.toml
+          time python -m pytest --durations 10 --reverse -p no:randomly -n auto --dist loadfile --cov --cov-report= --cov-config=pyproject.toml
           python -m coverage html --skip-covered --skip-empty
           python -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
           # python -m coverage report --fail-under=100

--- a/src/django_twc_project/.just/python.just.jinja
+++ b/src/django_twc_project/.just/python.just.jinja
@@ -17,15 +17,15 @@ codegen *ARGS:
     @just docker command "python manage.py runserver 0.0.0.0:8000 & while ! curl -s http://0.0.0.0:8000 > /dev/null; do sleep 1; done; playwright codegen {{ ARGS }}; kill %1"
 {%- endif %}
 
-# Run the test suite, generate code coverage, and export html report
+# Generate most recent code coverage report in HTML format
 [no-cd]
-coverage-html: test
+cov-html:
     rm -rf htmlcov
     @just docker command python -m coverage html --skip-covered --skip-empty
 
-# Run the test suite, generate code coverage, and print report to stdout
+# Print most recent code coverage report
 [no-cd]
-coverage-report: test
+cov-report:
     @just docker command python -m coverage report
 
 # Install dependencies

--- a/src/django_twc_project/Justfile.jinja
+++ b/src/django_twc_project/Justfile.jinja
@@ -68,13 +68,6 @@ makemigrations *ARGS:
 manage *COMMAND:
     @just dj manage {% raw %}{{ COMMAND }}{% endraw %}
 
-# Refresh local development environment
-refresh:
-    @just lock
-    @just docker stop
-    @just bootstrap
-    @just docker start
-
 # Setup local development environment
 setup:
     @just clean
@@ -83,7 +76,8 @@ setup:
     @just docker start
     @just dj migrate
     @just dj createsuperuser
-    @just py coverage-report
+    @just py test
+    @just py cov-report
     @just py types
     @just project lint
     @just docker down
@@ -92,18 +86,20 @@ setup:
 shell CONTAINER="app" COMMAND="":
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ {% raw %}{{ CONTAINER }}{% endraw %} = 'db' ]; then
+    CONTAINER="{% raw %}{{ CONTAINER }}{% endraw %}"
+    if [ $CONTAINER = "db" ]; then
         COMMAND="psql -d {% raw %}{{ DATABASE_URL }}{% endraw %}"
-    elif [ "{% raw %}{{ CONTAINER }}{% endraw %}" = "node" ] || [ "{% raw %}{{ CONTAINER }}{% endraw %}" = "tailwind" ]; then
+    elif [ $CONTAINER = "node" ] || [ $CONTAINER = "tailwind" ]; then
         COMMAND="node"
-    elif [ "{% raw %}{{ CONTAINER }}{% endraw %}" = "app" ] || [ "{% raw %}{{ CONTAINER }}{% endraw %}" = "worker" ]; then
+    elif [ $CONTAINER = "app" ] || [ $CONTAINER = "worker" ]; then
         COMMAND="ipython"
-    elif [ {% raw %}{{ CONTAINER }}{% endraw %} = 'dj' ]; then
+    elif [ $CONTAINER = "dj" ]; then
+        CONTAINER="app"
         COMMAND="python -m manage shell_plus"
     fi
     [ -n "{% raw %}{{ COMMAND }}{% endraw %}" ] && COMMAND="{% raw %}{{ COMMAND }}{% endraw %}"
     COMMAND="${COMMAND:-/bin/bash}"
-    just docker run {% raw %}{{ CONTAINER }}{% endraw %} "" $COMMAND
+    just --quiet docker run $CONTAINER "" $COMMAND
 
 # Start local development environment in background
 start:
@@ -120,13 +116,14 @@ tail *ARGS:
 # Run entire test suite, including generating code coverage
 test:
     @just py test
-    @just py coverage-html
+    @just py cov-report
+    @just py cov-html
 
 # Start local development environment in foreground
 up:
     @just docker up
 
-# Update local development environment
+# Refresh and update local development environment
 update:
     @just docker pull
     @just lock

--- a/src/django_twc_project/pyproject.toml.jinja
+++ b/src/django_twc_project/pyproject.toml.jinja
@@ -203,7 +203,7 @@ ignore_missing_model_attributes = true
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.settings"
-addopts = "--reuse-db -n auto --dist loadfile --cov={{ module_name }} --cov-report= --cov-config=pyproject.toml"
+addopts = "--reuse-db -n auto --dist loadfile --cov --cov-report= --cov-config=pyproject.toml"
 norecursedirs = ".* bin build dist *.egg htmlcov logs node_modules static templates venv"
 python_files = "tests.py test_*.py *_tests.py"
 


### PR DESCRIPTION
- Remove module name from `--cov` CLI flag for pytest-cov and allow it to read the config for what modules to cover
- Shorten coverage commands in `py` module
- Remove `test` command as prereq for coverage commands; this seems like a good idea (always ensure the test command runs) but ends up doubling up running the test suite, depending on the order they are called.
- Remove `refresh` command as it has too much overlap with `update`
- Ensure `shell` command enters the app container if `dj` is passed