### PR TITLE
:tractor: Run pre-commit via uv tool in template lint recipe

### DIFF
--- a/src/django_twc_project/.just/project.just
+++ b/src/django_twc_project/.just/project.just
@@ -84,8 +84,8 @@ just-fmt:
 
 # Run pre-commit on all files
 [no-cd]
-lint: install-precommit
-    $python -m pre_commit run --all-files
+lint:
+    uv run --with pre-commit-uv pre-commit run --all-files
     @just project just-fmt
 
 # Setup project scaffolding


### PR DESCRIPTION
Closes #327.

Switches the generated project's `lint` recipe to invoke pre-commit through uv's tool feature, matching the pattern this repo already uses in its own `justfile`.

### Before
```justfile
lint: install-precommit
    $python -m pre_commit run --all-files
    @just project just-fmt
```

### After
```justfile
lint:
    uv run --with pre-commit-uv pre-commit run --all-files
    @just project just-fmt
```

### Notes
- `install-precommit` is **kept** — it's still used by `setup` to install git hooks. Only `lint`'s dependency on it is dropped, so `lint` no longer installs anything into the venv just to run pre-commit.
- `pre-commit-uv` speeds up hook environment creation.
- Verified: examples regenerate cleanly and the generated justfile parses.