### PR TITLE
chore: enable core Ruff rule groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,13 +87,26 @@ quote-style = "double"
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
+fixable = ["ALL"]
 ignore = ["E501", "E741"]  # temporary
 select = [
+  "A",  # flake8-builtins
   "B",  # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "DJ",  # flake8-django
+  "DTZ",  # flake8-datetimez
   "E",  # Pycodestyle
   "F",  # Pyflakes
+  "G",  # flake8-logging-format
   "I",  # isort
+  "LOG",  # flake8-logging
+  "PIE",  # flake8-pie
+  "PT",  # flake8-pytest-style
+  "RET",  # flake8-return
+  "RUF100",  # unused noqa
+  "S",  # flake8-bandit
+  "SIM",  # flake8-simplify
+  "T20",  # flake8-print
   "UP"  # pyupgrade
 ]
 unfixable = []

--- a/src/django_twc_project/pyproject.toml.jinja
+++ b/src/django_twc_project/pyproject.toml.jinja
@@ -241,13 +241,26 @@ quote-style = "double"
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
+fixable = ["ALL"]
 ignore = ["E501", "E741"]  # temporary
 select = [
+  "A",  # flake8-builtins
   "B",  # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "DJ",  # flake8-django
+  "DTZ",  # flake8-datetimez
   "E",  # Pycodestyle
   "F",  # Pyflakes
+  "G",  # flake8-logging-format
   "I",  # isort
+  "LOG",  # flake8-logging
+  "PIE",  # flake8-pie
+  "PT",  # flake8-pytest-style
+  "RET",  # flake8-return
+  "RUF100",  # unused noqa
+  "S",  # flake8-bandit
+  "SIM",  # flake8-simplify
+  "T20",  # flake8-print
   "UP"  # pyupgrade
 ]
 unfixable = []


### PR DESCRIPTION
## Summary
- Enable the shared core Ruff rule groups for `django-twc-project`.
- Apply trivial fixes and targeted ignores so Ruff passes.

## Validation
- `uv run --python 3.12 ruff check .`

## Why these rules

The goal here is a boring, broadly useful Ruff baseline for Python/Django projects: catch correctness issues, framework-specific mistakes, test quality problems, security footguns, naive datetime usage, logging problems, and low-noise readability issues without enabling higher-churn families like `ANN`, `ARG`, full `PL`, full `RUF`, or `TRY`.

| Ruff code | What it is | Why it is a good default |
|---|---|---|
| `E` | `pycodestyle` errors | A small baseline for Python style errors that are not handled purely by formatting. These are familiar, low-surprise checks. |
| `F` | `Pyflakes` | High-signal correctness checks: undefined names, unused imports, duplicate definitions, invalid string formatting, and other issues that are often real bugs. |
| `I` | `isort` import sorting | Keeps import blocks deterministic and easy to review. This removes one common source of mechanical diff noise. |
| `B` | `flake8-bugbear` | Catches practical Python footguns: mutable defaults, problematic exception handling, loop-binding mistakes, useless expressions, and similar bug-prone patterns. |
| `UP` | `pyupgrade` | Keeps code aligned with the repository's target Python version and removes obsolete compatibility patterns. This helps the codebase stay consistent as Python versions move forward. |
| `DJ` | `flake8-django` | Adds Django-specific checks for models, forms, and framework conventions. These catch issues general Python linters cannot see, such as risky `ModelForm` exposure or model definition problems. |
| `PT` | `flake8-pytest-style` | Keeps tests idiomatic and consistent: parametrization shape, `pytest.raises` usage, fixture style, and pytest-vs-unittest assertion patterns. |
| `S` | Bandit security rules | Provides a baseline for common security-sensitive mistakes: suspicious `mark_safe`, hardcoded secrets, weak randomness, subprocess hazards, unsafe temp files, and raw SQL-ish patterns. It is not a full security review, but it is a useful default safety net. |
| `DTZ` | timezone-aware datetime rules | Especially useful in Django apps, where naive datetimes can become production bugs. These rules encourage explicit timezone-aware datetime usage. |
| `G` | `flake8-logging-format` | Enforces lazy logging formatting instead of f-strings, `.format()`, or `%` interpolation before the log call. This preserves normal logging behavior and avoids doing formatting work when the message is not emitted. |
| `LOG` | logging convention rules | Catches broader logging issues such as root logger usage, weak exception logging, redundant exception text, and logger setup problems. Good logging conventions improve diagnostics without changing application behavior. |
| `T20` | `print()` checks | In application and package code, stdout is usually the wrong interface for diagnostics. This nudges code toward logging, explicit CLI output, test assertions, or deletion. |
| `A` | builtin shadowing | Flags names like `id`, `type`, `list`, `filter`, and `input`. Avoiding builtin shadowing keeps code clearer and avoids subtle surprises when those builtins are needed later. |
| `C4` | comprehension cleanup | Catches redundant or inefficient comprehension patterns, such as unnecessary intermediate lists. These are usually straightforward readability/performance improvements. |
| `PIE` | `flake8-pie` small correctness/cleanup rules | A collection of low-noise checks for minor correctness and maintainability issues, such as unnecessary kwargs expansion, duplicate enum values, and repeated `startswith`/`endswith` patterns. |
| `RET` | return-path cleanup | Simplifies control flow by catching unnecessary `else` after `return`, redundant assignment-before-return, and implicit return patterns. The result is easier-to-scan functions. |
| `SIM` | `flake8-simplify` | Finds simpler equivalent forms for common conditionals and expressions, such as `x in dict.keys()`, collapsible `if` statements, or redundant boolean logic. Useful when the simplification is obvious and low risk. |
| `RUF100` | unused `noqa` comments | Keeps suppressions honest. Dead `noqa` comments make it harder to tell which suppressions are still intentional and can hide future issues. |
