### PR TITLE
Fix ruff A001 in docs/conf.py and bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.20
     hooks:
       - id: ruff
         args: [--fix]
@@ -39,7 +39,7 @@ repos:
         files: '^(?!.*\.min\..*)(?P<name>[\w-]+(\.[\w-]+)*\.(js|jsx|ts|tsx|yml|yaml|css))$'
 
   - repo: https://github.com/djlint/djLint
-    rev: v1.39.2
+    rev: v1.39.5
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django

--- a/examples/default/pyproject.toml
+++ b/examples/default/pyproject.toml
@@ -263,10 +263,10 @@ known-first-party = ["default"]
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
 # Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
 "**/docs/conf.py" = ["A001"]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/examples/default/pyproject.toml
+++ b/examples/default/pyproject.toml
@@ -265,6 +265,8 @@ required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
+"**/docs/conf.py" = ["A001"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/examples/postgis/pyproject.toml
+++ b/examples/postgis/pyproject.toml
@@ -263,10 +263,10 @@ known-first-party = ["default"]
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
 # Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
 "**/docs/conf.py" = ["A001"]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/examples/postgis/pyproject.toml
+++ b/examples/postgis/pyproject.toml
@@ -265,6 +265,8 @@ required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
+"**/docs/conf.py" = ["A001"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/examples/with_vite/pyproject.toml
+++ b/examples/with_vite/pyproject.toml
@@ -266,6 +266,8 @@ required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
+"**/docs/conf.py" = ["A001"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/examples/with_vite/pyproject.toml
+++ b/examples/with_vite/pyproject.toml
@@ -264,10 +264,10 @@ known-first-party = ["with_vite"]
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
 # Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
 "**/docs/conf.py" = ["A001"]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,10 @@ known-first-party = []
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
 # Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
 "**/docs/conf.py" = ["A001"]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
+"**/docs/conf.py" = ["A001"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/src/django_twc_project/pyproject.toml.jinja
+++ b/src/django_twc_project/pyproject.toml.jinja
@@ -273,6 +273,8 @@ required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Sphinx's conf.py uses `copyright`, which shadows a builtin (A001)
+"**/docs/conf.py" = ["A001"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.


### PR DESCRIPTION
## What

Supersedes #444 (the stuck `[pre-commit.ci] pre-commit autoupdate`). Applies the same hook bumps **plus** the fix for the lint failure that was blocking it:

- Bump `ruff` `v0.15.18 → v0.15.20` and `djLint` `v1.39.2 → v1.39.5` (matching #444).
- Add a scoped `per-file-ignores` entry `"**/docs/conf.py" = ["A001"]` to the template (`src/django_twc_project/pyproject.toml.jinja`), the root `pyproject.toml`, and the three generated example projects.

## Why

The newer ruff flags **`A001` — `copyright` shadows a Python builtin** in Sphinx's `docs/conf.py` (lines like `copyright = "2023, John Doe"`). `copyright` is a required Sphinx config variable, and `A001` is not auto-fixable, so `pre-commit.ci - pr` failed and #444 couldn't merge.

The ignore is added to the template so regenerated/seeded projects stay clean, and to the already-generated `examples/*` (whose own `pyproject.toml` is what ruff resolves) so this repo's CI passes now.

Verified locally with `ruff 0.15.20`: `All checks passed!` on all three `docs/conf.py` files.

Closes #444