### PR TITLE
Remove SECRET_KEY fallback

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,6 @@ _answers_file: .copier/project.yml
 _jinja_extensions:
   - copier_templates_extensions.TemplateExtensionLoader
   - extensions/context.py:DjangoNextVersion
-  - extensions/context.py:SecretKey
 _min_copier_version: "9.1.0"
 _secret_questions:
   - django_twc_ui_token

--- a/examples/default/templates/base.html
+++ b/examples/default/templates/base.html
@@ -8,11 +8,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>
-
       {% block title %}
         Default
       {% endblock title %}
-
     </title>
     <meta name="description" content="">
     <meta name="author" content="">
@@ -73,23 +71,18 @@
 
     {% block javascript_head %}
     {% endblock javascript_head %}
-
   </head>
 
   {% block body %}
     <body {% if debug %}class="debug-screens"{% endif %}
           hx-ext="head-support, preload">
       <main class="mt-16">
-
         {% block content %}
         {% endblock content %}
-
       </main>
 
       {% block javascript_foot %}
       {% endblock javascript_foot %}
-
     </body>
   {% endblock body %}
-
 </html>

--- a/examples/postgis/templates/base.html
+++ b/examples/postgis/templates/base.html
@@ -8,11 +8,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>
-
       {% block title %}
         Default
       {% endblock title %}
-
     </title>
     <meta name="description" content="">
     <meta name="author" content="">
@@ -73,23 +71,18 @@
 
     {% block javascript_head %}
     {% endblock javascript_head %}
-
   </head>
 
   {% block body %}
     <body {% if debug %}class="debug-screens"{% endif %}
           hx-ext="head-support, preload">
       <main class="mt-16">
-
         {% block content %}
         {% endblock content %}
-
       </main>
 
       {% block javascript_foot %}
       {% endblock javascript_foot %}
-
     </body>
   {% endblock body %}
-
 </html>

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import secrets
 import sys
 from typing import cast
 
@@ -10,13 +9,6 @@ else:
     from typing_extensions import override
 
 from copier_templates_extensions import ContextHook
-
-
-class SecretKey(ContextHook):
-    @override
-    def hook(self, context: dict[str, object]) -> dict[str, object]:
-        context["secret_key"] = secrets.token_hex(32)
-        return context
 
 
 class DjangoNextVersion(ContextHook):

--- a/src/django_twc_project/.env.example.jinja
+++ b/src/django_twc_project/.env.example.jinja
@@ -2,3 +2,4 @@ DATABASE_URL={{ postgres_uri_scheme }}://postgres:postgres@db:5432/postgres
 DEBUG=True
 DJANGO_SETTINGS_MODULE={{ module_name }}.settings
 EMAIL_RELAY_DATABASE_URL={{ postgres_uri_scheme }}://postgres:postgres@db:5432/email_relay
+SECRET_KEY=django-insecure-please-change-me-before-going-to-prod

--- a/src/django_twc_project/.github/workflows/test.yml.jinja
+++ b/src/django_twc_project/.github/workflows/test.yml.jinja
@@ -13,6 +13,7 @@ env:
   FORCE_COLOR: 1
   NODE_VERSION: "{{ node_version }}"
   PYTHON_VERSION: "{{ python_version }}"
+  SECRET_KEY: django-insecure-ci-only-not-a-production-secret
 
 permissions:
   contents: read

--- a/src/django_twc_project/Dockerfile.jinja
+++ b/src/django_twc_project/Dockerfile.jinja
@@ -126,6 +126,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 
 FROM node as node-final
 ENV DATABASE_URL sqlite://:memory:
+ENV SECRET_KEY django-insecure-build-only
 COPY --from=tailwind --link /usr/local /usr/local
 COPY --from=app --link /app /app
 COPY --link static/src /app/static/src
@@ -141,6 +142,7 @@ RUN python manage.py tailwind --skip-checks build
 
 FROM app as static
 ENV DATABASE_URL sqlite://:memory:
+ENV SECRET_KEY django-insecure-build-only
 COPY --from=py-dev --link /usr/local /usr/local
 COPY --from=node-final --link /app/static/dist /app/static/dist
 COPY --from=node-final --link /app/package*.json /app/

--- a/src/django_twc_project/{{ module_name }}/settings.py.jinja
+++ b/src/django_twc_project/{{ module_name }}/settings.py.jinja
@@ -265,10 +265,7 @@ if DEBUG:
 
 ROOT_URLCONF = "{{ module_name }}.urls"
 
-SECRET_KEY = env.str(
-    "SECRET_KEY",
-    default="{{ secret_key }}",
-)
+SECRET_KEY: str = env.str("SECRET_KEY")
 
 SECURE_HSTS_INCLUDE_SUBDOMAINS = PROD
 


### PR DESCRIPTION
Matches the fix Josh landed across the apps (lodge#667, assets#810, cms#2281, directory#488, minerals#482, spi#630) — this is the upstream source of that bug.

The template baked the copier-generated `secret_key` into `settings.py` as the `SECRET_KEY` default, so every generated project shipped a committed secret that a deploy would silently fall back to if the env var were ever missing. That is why each of the nine apps has its own distinct committed hex key.

## Changes

- `{{ module_name }}/settings.py.jinja` — `SECRET_KEY: str = env.str("SECRET_KEY")`, no default.
- `.env.example.jinja` — add a `django-insecure-…` placeholder so local dev still boots.
- `.github/workflows/test.yml.jinja` — add a throwaway `SECRET_KEY` to the workflow `env:` block; CI has no real secret.
- `Dockerfile.jinja` — add `ENV SECRET_KEY django-insecure-build-only` to the `node-final` and `static` stages, which run `manage.py tailwind build` / `collectstatic`.
- `extensions/context.py` + `copier.yml` — drop the now-unused `SecretKey` context hook; `secret_key` had no other consumers.

Production is unaffected: `.env.prod.jinja` already sources `SECRET_KEY` from 1Password (`op://fly/<app>/secret_key`).

## Verification

Rendered `examples/default.yml` against this branch and confirmed the four generated files come out identical in shape to the merged app PRs. Examples in-repo are regenerated by the `examples` workflow on push to `main`, so they are not updated here.